### PR TITLE
Draft43 trust mark evaluation

### DIFF
--- a/src/fedservice/entity/__init__.py
+++ b/src/fedservice/entity/__init__.py
@@ -3,9 +3,7 @@ from typing import Callable
 from typing import Optional
 from typing import Union
 
-from cryptojwt import as_unicode
 from cryptojwt import KeyJar
-from cryptojwt.jws.jws import factory
 from cryptojwt.utils import importer
 from idpyoidc.client.client_auth import client_auth_setup
 from idpyoidc.server.util import execute
@@ -246,10 +244,10 @@ class FederationEntity(Unit):
                     return _trust_chains[ta_id]
         return _trust_chains[_tas[0]]
 
-    def get_payload(self, self_signed_statement):
-        _jws = as_unicode(self_signed_statement)
-        _jwt = factory(_jws)
-        return _jwt.jwt.payload()
+    # def get_payload(self, self_signed_statement):
+    #     _jws = as_unicode(self_signed_statement)
+    #     _jwt = factory(_jws)
+    #     return _jwt.jwt.payload()
 
     def supported(self):
         _supports = self.context.supports()

--- a/src/fedservice/entity/function/__init__.py
+++ b/src/fedservice/entity/function/__init__.py
@@ -39,6 +39,13 @@ def verify_self_signed_signature(token):
     return _val
 
 
+def verify_signature(token, jwks, iss):
+    _keyjar = KeyJar()
+    _keyjar = import_jwks(_keyjar, jwks, iss)
+    _jwt = JWT(key_jar=_keyjar)
+    return _jwt.unpack(token)
+
+
 def tree2chains(unit):
     res = []
     for issuer, branch in unit.items():

--- a/src/fedservice/entity/function/trust_mark_verifier.py
+++ b/src/fedservice/entity/function/trust_mark_verifier.py
@@ -3,22 +3,34 @@ from typing import Callable
 from typing import Optional
 
 from cryptojwt import KeyJar
+from cryptojwt.exception import Expired
 from cryptojwt.jws.jws import factory
 from idpyoidc.key_import import import_jwks
+from idpyoidc.message import Message
 
 from fedservice import message
 from fedservice.entity import apply_policies
 from fedservice.entity.function import Function
 from fedservice.entity.function import get_payload
 from fedservice.entity.function import get_verified_trust_chains
+from fedservice.entity.function import verify_signature
+from fedservice.entity.function.trust_anchor import get_verified_trust_anchor_statement
 from fedservice.entity.utils import get_federation_entity
-from fedservice.utils import statement_is_expired
 
 logger = logging.getLogger(__name__)
 
 
 class TrustMarkVerifier(Function):
-
+    """
+    The steps are:
+    1) Verify the trust mark itself. That is; that it contains all the required claims and has not expired.
+    2) Check that the trust mark issuer is recognized by the trust anchor
+    3) If delegation is active.
+        a) verify that the delegator is recognized by the trust anchor
+        b) verify the signature of the delegation
+    4) Find a trust chain to the trust mark issuer
+    5) Verify the signature of the trust mark
+    """
     def __init__(self, upstream_get: Callable):
         Function.__init__(self, upstream_get)
 
@@ -27,7 +39,7 @@ class TrustMarkVerifier(Function):
                  trust_anchor: str,
                  check_status: Optional[bool] = False,
                  entity_id: Optional[str] = '',
-                 ):
+                 ) -> Optional[Message]:
         """
         Verifies that a trust mark is issued by someone in the federation and that
         the signing key is a federation key.
@@ -39,22 +51,51 @@ class TrustMarkVerifier(Function):
         payload = get_payload(trust_mark)
         _trust_mark = message.TrustMark(**payload)
         # Verify that everything that should be there, are there
-        _trust_mark.verify()
+        try:
+            _trust_mark.verify()
+        except Expired:  # Has it expired ?
+            return None
+        except ValueError:  # Not correct delegation ?
+            raise
 
-        # Has it expired ?
-        if statement_is_expired(_trust_mark):
+        # Get trust anchor information in order to verify the issuer and if needed the delegator.
+        _federation_entity = get_federation_entity(self)
+        trust_anchor_statement = get_verified_trust_anchor_statement(_federation_entity, trust_anchor)
+
+        # Trust mark issuers recognized by the trust anchor
+        _trust_mark_issuers = trust_anchor_statement.get("trust_mark_issuers")
+        if _trust_mark_issuers is None:  # No trust mark issuers are recognized by the trust anchor
+            return None
+        _issuers = _trust_mark_issuers.get(_trust_mark['trust_mark_id'])
+        if _issuers is None:
             return None
 
-        # deal with delegation
-        if 'delegation' in _trust_mark:
-            _delegation = self.verify_delegation(_trust_mark, trust_anchor)
-            if not _delegation:
-                logger.warning("Could not verify the delegation")
+        if _issuers == [] or _trust_mark["iss"] in _issuers:
+            pass
+        else:  # The trust mark issuer not trusted by the trust anchor
+            logger.warning(
+                f'Trust mark issuer {_trust_mark["iss"]} not trusted by the trust anchor for trust mar id: {_trust_mark["trust_mark_id"]}')
+            return None
 
-        # Get trust chain
-        # _federation_entity = get_federation_entity(self)
-        # _chains, entity_conf = collect_trust_chains(_federation_entity, _trust_mark['iss'])
-        # _trust_chains = verify_trust_chains(_federation_entity, _chains, entity_conf)
+        if "delegation" in _trust_mark:
+            _owners = trust_anchor_statement.get("trust_mark_owners", {})
+            if not _owners:
+                return None
+            _delegator = _owners.get(_trust_mark["trust_mark_id"])
+            # object with two parameters 'sub' and 'jwks'
+            if _delegator["sub"] != _trust_mark["__delegation"]["iss"]:
+                logger.warning(
+                    f"{_trust_mark['__delegation']['iss']} not recognized delegator for {_trust_mark['trust_mark_id']}")
+                return None
+            try:
+                _token = verify_signature(_trust_mark["delegation"], _delegator["jwks"], _delegator["sub"])
+            except Exception as err:
+                logger.exception("Verify delegation signature failed")
+                return None
+
+            # Might want to put _token in trust_mark[verified_claim_name("delegation")]
+
+        # Now time to verify the signature of the trust mark
         _trust_chains = get_verified_trust_chains(self, _trust_mark['iss'])
         if not _trust_chains:
             logger.warning(f"Could not find any verifiable trust chains for {_trust_mark['iss']}")
@@ -66,7 +107,6 @@ class TrustMarkVerifier(Function):
 
         # Now try to verify the signature on the trust_mark
         # should have the necessary keys
-        _federation_entity = get_federation_entity(self)
         _jwt = factory(trust_mark)
         keyjar = _federation_entity.get_attribute('keyjar')
 

--- a/src/fedservice/trust_mark_entity/server/trust_mark_list.py
+++ b/src/fedservice/trust_mark_entity/server/trust_mark_list.py
@@ -39,13 +39,13 @@ class TrustMarkList(Endpoint):
 
         if 'sub' in request and 'trust_mark_id' in request:
             if _trust_mark_entity.find(request['trust_mark_id'], request['sub']):
-                return {"foo": request["sub"]}
+                return {"response_msg": json.dumps([request["sub"]])}
         elif 'trust_mark_id' in request:
             _lst = _trust_mark_entity.list(request["trust_mark_id"])
             if _lst:
-                return {"response_msg": json.dumps(_lst), "response_code": 200}
+                return {"response_msg": json.dumps(_lst)}
 
-        return self.error_cls(error="not_found", error_description="No trust mark matching the query")
+        return {"response_msg": []}
 
     def response_info(
             self,

--- a/tests/test_08_trust_mark.py
+++ b/tests/test_08_trust_mark.py
@@ -36,6 +36,7 @@ FEDERATION_CONFIG = {
             },
             "endpoints": TA_ENDPOINTS,
             "services": TA_SERVICES,
+            "trust_mark_issuers": {"https://refeds.org/sirtfi": [TRUST_MARK_ISSUER_ID]}
         }
     },
     TRUST_MARK_ISSUER_ID: {

--- a/tests/test_45_subordinates.py
+++ b/tests/test_45_subordinates.py
@@ -54,7 +54,8 @@ class TestSubordinatePersistenceFileSystem(object):
     @pytest.fixture(autouse=True)
     def create_entities(self):
         _dir = full_path('subordinate')
-        rm_dir_files(_dir)
+        if os.path.exists(_dir):
+            rm_dir_files(_dir)
 
         federation = build_federation(FEDERATION_CONFIG)
         self.ta = federation[TA_ID]
@@ -69,9 +70,13 @@ class TestSubordinatePersistenceFileSystem(object):
         with open(fname, 'w') as f:
             f.write(json.dumps(_info))
 
-    def test_list(self):
+    def test_subordinate_list(self):
         _endpoint = self.ta.get_endpoint('list')
         _req = _endpoint.parse_request({})
         _resp_args = _endpoint.process_request(_req)
         assert _resp_args
         assert _resp_args['response_msg'] == f'["{self.rp["federation_entity"].entity_id}"]'
+        response = _endpoint.do_response(response_msg=_resp_args["response_msg"], request=_req)
+        assert response
+        assert response["response"] == '["https://rp.example.com"]'
+        assert ('Content-type', 'application/json') in response["http_headers"]

--- a/tests/test_52_trust_mark_verify.py
+++ b/tests/test_52_trust_mark_verify.py
@@ -30,6 +30,9 @@ FEDERATION_CONFIG = {
                 "contacts": "operations@ta.example.org"
             },
             "endpoints": ['entity_configuration', 'list', 'fetch', 'resolve'],
+            "trust_mark_issuers": {
+                "https://refeds.org/sirtfi": [TRUST_MARK_ISSUER_ID]
+            }
         }
     },
     IM_ID: {
@@ -133,7 +136,7 @@ class TestComboCollect(object):
 
         _trust_mark = create_trust_mark(entity_id=self.tmi.entity_id,
                                         keyjar=self.tmi.get_attribute('keyjar'),
-                                        trust_mark_id=rndstr(),
+                                        trust_mark_id="https://refeds.org/sirtfi",
                                         sub=self.rp.entity_id,
                                         lifetime=3600,
                                         reference='https://refeds.org/sirtfi')

--- a/tests/test_56_trust_mark_delegation.py
+++ b/tests/test_56_trust_mark_delegation.py
@@ -38,7 +38,7 @@ FEDERATION_CONFIG = {
                                         'sub': TM_OWNERS_ID}
             },
             "trust_mark_issuers": {
-                SIRTIFI_TRUST_MARK_ID: TMI_ID
+                SIRTIFI_TRUST_MARK_ID: [TMI_ID]
             },
             "endpoints": ['entity_configuration', 'list', 'fetch', 'resolve'],
         }

--- a/tests/test_56_trust_mark_delegation.py
+++ b/tests/test_56_trust_mark_delegation.py
@@ -1,12 +1,12 @@
 import os
 from urllib.parse import urlparse
 
+import pytest
+import responses
 from cryptojwt import JWT
 from cryptojwt.jws.jws import factory
 from cryptojwt.key_jar import build_keyjar
 from idpyoidc.client.defaults import DEFAULT_KEY_DEFS
-import pytest
-import responses
 
 from fedservice.message import TrustMarkRequest
 from tests import create_trust_chain_messages
@@ -16,6 +16,7 @@ TRUST_MARK_OWNERS_KEYS = build_keyjar(DEFAULT_KEY_DEFS)
 TM_OWNERS_ID = "https://tm_owner.example.org"
 
 SIRTIFI_TRUST_MARK_ID = "https://refeds.org/sirtfi"
+MUSHROOM_TRUST_MARK_ID = "https://mushrooms.federation.example.com/arrosto/agreements"
 
 BASE_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -35,10 +36,15 @@ FEDERATION_CONFIG = {
             },
             "trust_mark_owners": {
                 SIRTIFI_TRUST_MARK_ID: {'jwks': TRUST_MARK_OWNERS_KEYS.export_jwks(),
-                                        'sub': TM_OWNERS_ID}
+                                        'sub': TM_OWNERS_ID},
+                MUSHROOM_TRUST_MARK_ID: {
+                    'jwks': TRUST_MARK_OWNERS_KEYS.export_jwks(),
+                    'sub': TM_OWNERS_ID
+                }
             },
             "trust_mark_issuers": {
-                SIRTIFI_TRUST_MARK_ID: [TMI_ID]
+                SIRTIFI_TRUST_MARK_ID: [TMI_ID],
+                MUSHROOM_TRUST_MARK_ID: []
             },
             "endpoints": ['entity_configuration', 'list', 'fetch', 'resolve'],
         }
@@ -52,14 +58,14 @@ FEDERATION_CONFIG = {
                 "class": "fedservice.trust_mark_entity.entity.TrustMarkEntity",
                 "kwargs": {
                     "trust_mark_specification": {
-                        "https://refeds.org/sirtfi": {
-                            "lifetime": 2592000
-                        }
+                        SIRTIFI_TRUST_MARK_ID: {"lifetime": 2592000},
+                        MUSHROOM_TRUST_MARK_ID: {"lifetime": 2592000}
                     },
                     "trust_mark_db": {
                         "class": "fedservice.trust_mark_entity.FileDB",
                         "kwargs": {
-                            "https://refeds.org/sirtfi": "sirtfi",
+                            SIRTIFI_TRUST_MARK_ID: "sirtfi",
+                            MUSHROOM_TRUST_MARK_ID: "mushroom"
                         }
                     },
                     "endpoint": {
@@ -112,8 +118,13 @@ def tm_receiver():
 def trust_mark_delegation(tm_receiver):
     _jwt = JWT(TRUST_MARK_OWNERS_KEYS, iss=TM_OWNERS_ID, sign_alg='RS256')
     return _jwt.pack({'sub': TMI_ID, "trust_mark_id": SIRTIFI_TRUST_MARK_ID},
-                     jws_headers={"typ":"trust-mark-delegation+jwt"})
+                     jws_headers={"typ": "trust-mark-delegation+jwt"})
 
+@pytest.fixture()
+def mushroom_trust_mark_delegation(tm_receiver):
+    _jwt = JWT(TRUST_MARK_OWNERS_KEYS, iss=TM_OWNERS_ID, sign_alg='RS256')
+    return _jwt.pack({'sub': TMI_ID, "trust_mark_id": MUSHROOM_TRUST_MARK_ID},
+                     jws_headers={"typ": "trust-mark-delegation+jwt"})
 
 class TestTrustMarkDelegation():
 
@@ -129,6 +140,12 @@ class TestTrustMarkDelegation():
         self.tmi.server.trust_mark_entity.trust_mark_specification[SIRTIFI_TRUST_MARK_ID] = {
             "delegation": trust_mark_delegation}
         return self.tmi.server.trust_mark_entity.create_trust_mark(SIRTIFI_TRUST_MARK_ID, tm_receiver)
+
+    @pytest.fixture()
+    def create_mushroom_trust_mark(self, mushroom_trust_mark_delegation, tm_receiver):
+        self.tmi.server.trust_mark_entity.trust_mark_specification[MUSHROOM_TRUST_MARK_ID] = {
+            "delegation": mushroom_trust_mark_delegation}
+        return self.tmi.server.trust_mark_entity.create_trust_mark(MUSHROOM_TRUST_MARK_ID, tm_receiver)
 
     def test_delegated_trust_mark(self, create_trust_mark):
         _trust_mark = create_trust_mark
@@ -156,7 +173,7 @@ class TestTrustMarkDelegation():
 
         assert verified_trust_mark
 
-        # The collector hold all the entity statements/configurations that has been seen so far.
+        # The collector holds all entity statements/configurations that has been seen so far.
         _collector = self.fe.function.trust_chain_collector
 
         # Ask the trust mark issuer if the trust mark is still valid
@@ -179,3 +196,45 @@ class TestTrustMarkDelegation():
         resp = self.tmi.server.endpoint['trust_mark_status'].process_request(
             tmr.to_dict())
         assert resp == {'response_args': {'active': True}}
+
+    def test_verify_mushroom_trust_mark(self, create_mushroom_trust_mark):
+        _trust_mark = create_mushroom_trust_mark
+
+        # (1) verify signature and that it is still active
+        # a) trust chain for trust mark issuer
+
+        where_and_what = create_trust_chain_messages(self.tmi, self.ta)
+        with responses.RequestsMock() as rsps:
+            for _url, _jwks in where_and_what.items():
+                rsps.add("GET", _url, body=_jwks,
+                         adding_headers={"Content-Type": "application/json"}, status=200)
+
+            verified_trust_mark = self.fe.function.trust_mark_verifier(
+                trust_mark=_trust_mark, trust_anchor=self.ta.entity_id)
+
+        assert verified_trust_mark
+
+    @pytest.fixture()
+    def create_mushroom_trust_mark_sans_delegation(self, mushroom_trust_mark_delegation, tm_receiver):
+        self.tmi.server.trust_mark_entity.trust_mark_specification[MUSHROOM_TRUST_MARK_ID] = {}
+        return self.tmi.server.trust_mark_entity.create_trust_mark(MUSHROOM_TRUST_MARK_ID, tm_receiver)
+
+    def test_verify_mushroom_trust_mark_not_delegated(self, create_mushroom_trust_mark_sans_delegation):
+        _trust_mark = create_mushroom_trust_mark_sans_delegation
+
+        # (1) verify signature and that it is still active
+        # a) trust chain for trust mark issuer
+
+        where_and_what = create_trust_chain_messages(self.tmi, self.ta)
+        # Will not be looking for a trust chain
+        del where_and_what['https://tmi.example.org/.well-known/openid-federation']
+        del where_and_what['https://ta.example.org/fetch']
+        with responses.RequestsMock() as rsps:
+            for _url, _jwks in where_and_what.items():
+                rsps.add("GET", _url, body=_jwks,
+                         adding_headers={"Content-Type": "application/json"}, status=200)
+
+            verified_trust_mark = self.fe.function.trust_mark_verifier(
+                trust_mark=_trust_mark, trust_anchor=self.ta.entity_id)
+
+        assert verified_trust_mark == None

--- a/tests/test_70_trust_marks.py
+++ b/tests/test_70_trust_marks.py
@@ -36,7 +36,7 @@ def get_client_info(client_id, endpoint):
         return {}
 
 
-class TestTrustMarkDelegation():
+class TestTrustMarkEndpoints():
 
     @pytest.fixture(autouse=True)
     def setup(self):
@@ -156,9 +156,9 @@ class TestTrustMarkDelegation():
         _req = Message().from_urlencoded(_query)
         _parse_req = _server_endpoint.parse_request(_req.to_dict())
         _hw_resp = _server_endpoint.process_request(_parse_req)
-        _resp = _server_endpoint.do_response(_hw_resp)
-        assert _resp
-        assert "error" in _resp["response"]
+        _resp = _server_endpoint.do_response(**_hw_resp)
+        assert set(_resp.keys()) == {"response", "http_headers"}
+        assert _resp["response"] == []
 
     def test_get_trust_mark(self):
         self.federation_entity.client.context.issuer = self.trust_mark_issuer.entity_id


### PR DESCRIPTION
Updated to follow draft 43 of OpenID Federation
Fixed trust mark verification
Finding no trust marks to return for a list request is not an error